### PR TITLE
Enable Spotify API, fix test cleanup

### DIFF
--- a/spotify-podcast-player-backend/package.json
+++ b/spotify-podcast-player-backend/package.json
@@ -7,7 +7,7 @@
     "serve": "nx serve",
     "build": "nx build",
     "migratetest": "npx prisma migrate deploy",
-    "test": "nx test"
+    "test": "nx test --skip-nx-cache"
   },
   "private": true,
   "dependencies": {

--- a/spotify-podcast-player-backend/src/routes/users.ts
+++ b/spotify-podcast-player-backend/src/routes/users.ts
@@ -1,11 +1,10 @@
 import { generateAccessToken } from '../tokens'
 import { prisma } from '../database'
-//import getSpotifyProfile from './spotify'
+import getSpotifyProfile from '../spotify'
 
 const createUser = async (req, res) => {
-  //const spotifyId = await getSpotifyProfile('hello')
-  // TODO remove hardcoded spotifyId
-  const spotifyId = 'helloworld1234'
+  const spotifyId = await getSpotifyProfile(req.body.spotifyToken)
+  //const spotifyId = req.body.spotifyToken
 
   if (spotifyId === null) {
     res.send({

--- a/spotify-podcast-player-backend/tests/categories.test.ts
+++ b/spotify-podcast-player-backend/tests/categories.test.ts
@@ -3,16 +3,9 @@ import { prisma } from '../src/database'
 import app from '../src/app'
 import { getAuthHeader } from './helpers'
 
-afterEach(async () => {
-  await prisma.userFavorite.deleteMany({})
-  await prisma.categoryShow.deleteMany({})
-  await prisma.category.deleteMany({})
-  await prisma.user.deleteMany({})
-})
-
 test('add category', async () => {
   const user = await prisma.user.create({
-    data: { id: 'someuniqueid' },
+    data: { id: 'someuniqueidaddcategory' },
   })
   const authHeader = getAuthHeader(user.id)
   const data = { name: 'Category A' }
@@ -34,11 +27,14 @@ test('add category', async () => {
     where: { userId: user.id },
   })
   expect(count).toBe(1)
+
+  await prisma.category.deleteMany({where : {userId: user.id}})
+  await prisma.user.delete({where : {id: user.id}})
 })
 
 test('delete category', async () => {
   const user = await prisma.user.create({
-    data: { id: 'someuniqueid' },
+    data: { id: 'someuniqueiddeletecategory' },
   })
   const authHeader = getAuthHeader(user.id)
   const data = { name: 'category A' }
@@ -64,11 +60,14 @@ test('delete category', async () => {
     where: { userId: user.id },
   })
   expect(count).toBe(0)
+
+  await prisma.category.deleteMany({where : {userId: user.id}})
+  await prisma.user.delete({where : {id: user.id}})
 })
 
 test('update category', async () => {
   const user = await prisma.user.create({
-    data: { id: 'someuniqueid' },
+    data: { id: 'someuniqueidupdatecategory' },
   })
   const authHeader = getAuthHeader(user.id)
   const data = { name: 'category A' }
@@ -95,11 +94,14 @@ test('update category', async () => {
     .set('Authorization', authHeader)
     .send(data)
   expect(resp.status).toBe(409)
+
+  await prisma.category.deleteMany({where : {userId: user.id}})
+  await prisma.user.delete({where : {id: user.id}})
 })
 
 test('list categories', async () => {
   const user = await prisma.user.create({
-    data: { id: 'someuniqueid' },
+    data: { id: 'someuniqueidlistcategory' },
   })
   const authHeader = getAuthHeader(user.id)
 
@@ -128,4 +130,7 @@ test('list categories', async () => {
   const ids = resp.body.categories.map((c) => c.id)
   expect(ids).toContain(category.id.toString())
   expect(ids).toContain(category2.id.toString())
+
+  await prisma.category.deleteMany({where : {userId: user.id}})
+  await prisma.user.delete({where : {id: user.id}})
 })

--- a/spotify-podcast-player-backend/tests/categoryShows.test.ts
+++ b/spotify-podcast-player-backend/tests/categoryShows.test.ts
@@ -3,16 +3,9 @@ import { prisma } from '../src/database'
 import app from '../src/app'
 import { getAuthHeader } from './helpers'
 
-afterEach(async () => {
-  await prisma.userFavorite.deleteMany({})
-  await prisma.categoryShow.deleteMany({})
-  await prisma.category.deleteMany({})
-  await prisma.user.deleteMany({})
-})
-
 test('add categoryShow', async () => {
   const user = await prisma.user.create({
-    data: { id: 'someuniqueid' },
+    data: { id: 'someuniqueidaddcategoryshow' },
   })
   const authHeader = getAuthHeader(user.id)
   const category = await prisma.category.create({
@@ -40,11 +33,15 @@ test('add categoryShow', async () => {
     .send()
   expect(resp.status).toBe(200)
   expect(resp.body.categories[0].savedShows[0].id).toBe(data.showId)
+
+  await prisma.categoryShow.deleteMany({where : {showId: data.showId}})
+  await prisma.category.deleteMany({where : {userId: user.id}})
+  await prisma.user.delete({where : {id: user.id}})
 })
 
-test('delete category', async () => {
+test('delete categoryshow', async () => {
   const user = await prisma.user.create({
-    data: { id: 'someuniqueid' },
+    data: { id: 'someuniqueiddeletecategoryshow' },
   })
   const authHeader = getAuthHeader(user.id)
   const category = await prisma.category.create({
@@ -77,4 +74,8 @@ test('delete category', async () => {
     .set('Authorization', authHeader)
     .send()
   expect(resp.status).toBe(404)
+
+  await prisma.categoryShow.deleteMany({where : {userId: user.id}})
+  await prisma.category.deleteMany({where : {userId: user.id}})
+  await prisma.user.delete({where : {id: user.id}})
 })

--- a/spotify-podcast-player-backend/tests/favorites.test.ts
+++ b/spotify-podcast-player-backend/tests/favorites.test.ts
@@ -3,16 +3,9 @@ import { prisma } from '../src/database'
 import app from '../src/app'
 import { getAuthHeader } from './helpers'
 
-afterEach(async () => {
-  await prisma.userFavorite.deleteMany({})
-  await prisma.categoryShow.deleteMany({})
-  await prisma.category.deleteMany({})
-  await prisma.user.deleteMany({})
-})
-
 test('add favorite', async () => {
   const user = await prisma.user.create({
-    data: { id: 'someuniqueid' },
+    data: { id: 'someuniqueidaddfavorite' },
   })
   const authHeader = getAuthHeader(user.id)
   const data = { episodeId: 'episode123' }
@@ -35,11 +28,14 @@ test('add favorite', async () => {
     .set('Authorization', authHeader)
     .send()
   expect(resp.body.savedEpisodes[0].id).toBe(data.episodeId)
+
+  await prisma.userFavorite.deleteMany({ where: { userId: user.id } })
+  await prisma.user.delete({ where: { id: user.id } })
 })
 
 test('delete favorite', async () => {
   const user = await prisma.user.create({
-    data: { id: 'someuniqueid' },
+    data: { id: 'someuniqueiddeletefavorite' },
   })
   const authHeader = getAuthHeader(user.id)
   const data = { episodeId: 'episode123' }
@@ -69,4 +65,6 @@ test('delete favorite', async () => {
     .set('Authorization', authHeader)
     .send()
   expect(resp.body.savedEpisodes).toHaveLength(0)
+
+  await prisma.user.delete({ where: { id: user.id } })
 })

--- a/spotify-podcast-player-backend/tests/models.test.ts
+++ b/spotify-podcast-player-backend/tests/models.test.ts
@@ -1,26 +1,17 @@
 import { prisma } from '../src/database'
 
-afterEach(async () => {
-  await prisma.userFavorite.deleteMany({})
-  await prisma.categoryShow.deleteMany({})
-  await prisma.category.deleteMany({})
-  await prisma.user.deleteMany({})
-})
-
 test('user model', async () => {
-  const users = await prisma.user.findMany({})
-  expect(users.length).toBe(0)
-
   const user = await prisma.user.create({
-    data: { id: 'someuniqueid' },
+    data: { id: 'someuniqueidaddusermodel' },
   })
 
   expect(user.createdAt).toBeDefined()
+  await prisma.user.delete({ where: { id: user.id } })
 })
 
 test('userfavorite model', async () => {
   const user = await prisma.user.create({
-    data: { id: 'someuniqueid' },
+    data: { id: 'someuniqueidadduserfave' },
   })
 
   const fave = await prisma.userFavorite.create({
@@ -32,6 +23,9 @@ test('userfavorite model', async () => {
 
   expect(fave.createdAt).toBeDefined()
   expect(fave.userId).toBe(user.id)
+
+  await prisma.userFavorite.deleteMany({ where: { userId: user.id } })
+  await prisma.user.delete({ where: { id: user.id } })
 })
 
 test('category model', async () => {
@@ -51,6 +45,9 @@ test('category model', async () => {
   expect(category.createdAt).toBeDefined()
   expect(category.userId).toBe(user.id)
   expect(category.name).toBe(categoryName)
+
+  await prisma.category.deleteMany({ where: { userId: user.id } })
+  await prisma.user.delete({ where: { id: user.id } })
 })
 
 test('categoryshow model', async () => {
@@ -79,4 +76,8 @@ test('categoryshow model', async () => {
   expect(categoryShow.userId).toBe(user.id)
   expect(categoryShow.categoryId).toBe(category.id)
   expect(categoryShow.showId).toBe(showId)
+
+  await prisma.categoryShow.deleteMany({ where: { userId: user.id } })
+  await prisma.category.deleteMany({ where: { userId: user.id } })
+  await prisma.user.delete({ where: { id: user.id } })
 })

--- a/spotify-podcast-player-backend/tests/users.test.ts
+++ b/spotify-podcast-player-backend/tests/users.test.ts
@@ -3,24 +3,29 @@ import app from '../src/app'
 import { prisma } from '../src/database'
 import { getAuthHeader } from './helpers'
 
-afterEach(async () => {
-  await prisma.userFavorite.deleteMany({})
-  await prisma.categoryShow.deleteMany({})
-  await prisma.category.deleteMany({})
-  await prisma.user.deleteMany({})
-})
+import axios from 'axios'
+import getSpotifyProfile from '../src/spotify'
+
 
 test('create user', async () => {
+  const spotifyId = 'someuniqueidadduser'
+
+  axios.get = jest.fn()
+  const mockResp = {data: {id: spotifyId}};
+  (axios.get as jest.Mock).mockResolvedValue(mockResp)
+
   const resp = await request(app)
     .post('/api/users')
-    .send({ id: 'someuniqueid' })
+    .send({ spotifyToken: spotifyId })
   expect(resp.status).toBe(200)
   expect(resp.body.token).toBeDefined()
+
+  await prisma.user.delete({ where: { id: spotifyId } })
 })
 
 test('me', async () => {
   const user = await prisma.user.create({
-    data: { id: 'someuniqueid' },
+    data: { id: 'someuniqueidme' },
   })
   const authHeader = getAuthHeader(user.id)
 
@@ -31,4 +36,6 @@ test('me', async () => {
   expect(resp.status).toBe(200)
   expect(resp.body.id).toBe(user.id)
   expect(resp.body.savedEpisodes).toHaveLength(0)
+
+  await prisma.user.delete({ where: { id: user.id } })
 })


### PR DESCRIPTION
- Disable test caching for backend (some race condition issues were not caught earlier)
- Enable fetching of user information using Spotify's API